### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ node_modules/
 dist/
 *.tgz
 
+# Chrome extension signing key (never commit)
+key.pem
+
 # Environment
 .env
 .env.*


### PR DESCRIPTION
Closes #474

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .gitignore